### PR TITLE
[Sprint 73] Modifica aviso sobre o elemento 'table'

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Você pode adicionar outros arquivos se julgar necessário. Qualquer dúvida, pr
 
 ### Dicas
 
-- Não recomenda-se a utilização de `table`, pois o sentido semântico de construir uma tabela no HTML não tem relação  com a construção de uma grade de pixels para serem coloridos. Nesse caso, fazer uso de `table` representa uma má prática. Se quiser uma sugestão, tente criar a grade usando linhas e colunas de `div`. ;)
+- Não recomenda-se a utilização de `table`, pois o sentido semântico de construir uma tabela no HTML não tem relação  com a construção de uma grade de pixels para serem coloridos. Nesse caso, fazer uso de `table` representa uma má prática.
 
 - [Que tal](https://flaviocopes.com/how-to-add-event-listener-multiple-elements-javascript/) usar um _loop_ para adicionar o mesmo evento em vários elementos? [Ou então](https://gomakethings.com/attaching-multiple-elements-to-a-single-event-listener-in-vanilla-js/) a técnica de _event bubbling_ combinada com `classList`?
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Você pode adicionar outros arquivos se julgar necessário. Qualquer dúvida, pr
 
 ### Dicas
 
-- Não use `table`. O sentido semântico de se construir uma tabela no HTML não tem a ver com construir uma grade de pixels para serem coloridos, por isso é uma má prática. Se quiser uma sugestão, tente criar a grade usando linhas e colunas de `div`. ;)
+- Não recomenda-se a utilização de `table`, pois o sentido semântico de construir uma tabela no HTML não tem relação  com a construção de uma grade de pixels para serem coloridos. Nesse caso, fazer uso de `table` representa uma má prática. Se quiser uma sugestão, tente criar a grade usando linhas e colunas de `div`. ;)
 
 - [Que tal](https://flaviocopes.com/how-to-add-event-listener-multiple-elements-javascript/) usar um _loop_ para adicionar o mesmo evento em vários elementos? [Ou então](https://gomakethings.com/attaching-multiple-elements-to-a-single-event-listener-in-vanilla-js/) a técnica de _event bubbling_ combinada com `classList`?
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Você pode adicionar outros arquivos se julgar necessário. Qualquer dúvida, pr
 
 ### Dicas
 
-- Você pode pesquisar sobre a propriedade `display` do CSS, [especificamente sobre as opções `table`, `table-row` e `table-cell`](https://stackoverflow.com/questions/29229523/how-and-why-to-use-display-table-cell-css) para te ajudar a posicionar os elementos;
+- 
 
 - [Que tal](https://flaviocopes.com/how-to-add-event-listener-multiple-elements-javascript/) usar um _loop_ para adicionar o mesmo evento em vários elementos? [Ou então](https://gomakethings.com/attaching-multiple-elements-to-a-single-event-listener-in-vanilla-js/) a técnica de _event bubbling_ combinada com `classList`?
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Você pode adicionar outros arquivos se julgar necessário. Qualquer dúvida, pr
 
 ### Dicas
 
-- 
+- Não use `table`. O sentido semântico de se construir uma tabela no HTML não tem a ver com construir uma grade de pixels para serem coloridos, por isso é uma má prática. Se quiser uma sugestão, tente criar a grade usando linhas e colunas de `div`. ;)
 
 - [Que tal](https://flaviocopes.com/how-to-add-event-listener-multiple-elements-javascript/) usar um _loop_ para adicionar o mesmo evento em vários elementos? [Ou então](https://gomakethings.com/attaching-multiple-elements-to-a-single-event-listener-in-vanilla-js/) a técnica de _event bubbling_ combinada com `classList`?
 


### PR DESCRIPTION
A demanda pede para que eu alinhe com as pessoas estudantes que utilizar a tag 'table' no display da grade dos pixels não é bom. 
A seção de dicas continha um link que sugeria a utilização do dsplay table no CSS sem a exibição de alguma informação, [o que também não é uma boa prática](https://stackoverflow.com/questions/2687968/is-it-bad-use-display-table-to-organise-a-layout-into-2-columns#:~:text=The%20reason%20%22tables%20are%20bad,not%20work%20for%20all%20browsers.). Logo, adicionei uma sugestão para que a pessoa simplesmente utilizasse uma grade de divs.

[#Link da issue](https://github.com/betrybe/course/issues/335)